### PR TITLE
fix(notifications): guard image-loader continuation against double resume

### DIFF
--- a/PushEngageSDK/src/main/java/com/pushengage/pushengage/notificationhandling/PENotificationImageLoader.kt
+++ b/PushEngageSDK/src/main/java/com/pushengage/pushengage/notificationhandling/PENotificationImageLoader.kt
@@ -19,8 +19,8 @@ import kotlinx.coroutines.async
 import kotlinx.coroutines.awaitAll
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
+import kotlinx.coroutines.suspendCancellableCoroutine
 import kotlin.coroutines.resume
-import kotlin.coroutines.suspendCoroutine
 
 internal interface PENotificationImageLoaderType {
     /**
@@ -85,27 +85,27 @@ internal class PENotificationImageLoader(private val context: Context) : PENotif
         }
     }
 
-    private suspend fun loadImageAsync(imageUrl: String): Bitmap? = suspendCoroutine { continuation ->
+    private suspend fun loadImageAsync(imageUrl: String): Bitmap? = suspendCancellableCoroutine { continuation ->
         try {
             Glide.with(context)
                     .asBitmap()
                     .load(imageUrl)
                     .into(object : CustomTarget<Bitmap?>() {
                         override fun onResourceReady(resource: Bitmap, transition: Transition<in Bitmap?>?) {
-                            continuation.resume(resource)
+                            if (continuation.isActive) continuation.resume(resource)
                         }
 
                         override fun onLoadCleared(placeholder: Drawable?) {
-                            continuation.resume(null)
+                            if (continuation.isActive) continuation.resume(null)
                         }
 
                         override fun onLoadFailed(errorDrawable: Drawable?) {
-                            continuation.resume(null)
+                            if (continuation.isActive) continuation.resume(null)
                         }
                     })
         } catch (e: Exception) {
             PELogger.error("PEImageLoader", e)
-            continuation.resume(null)
+            if (continuation.isActive) continuation.resume(null)
         }
     }
 


### PR DESCRIPTION
## Summary

`PENotificationImageLoader.loadImageAsync` wraps Glide in `suspendCoroutine` and forwards four resume sites (`onResourceReady`, `onLoadCleared`, `onLoadFailed`, plus a `catch` fallback) into the same one-shot continuation. When Glide fires more than one callback for the same load — which it does during target tear-down, especially when the FCM background service is killed mid-load — the second `resume()` throws `IllegalStateException("Already resumed")` and crashes the host process.

## Crash signature

```
java.lang.IllegalStateException: Already resumed
  at com.pushengage.pushengage.notificationhandling.PENotificationImageLoader$loadImageAsync$2$1.onResourceReady
```

(also fires from `.onLoadFailed` depending on which callback Glide emits second)

Reaches the user as a **fatal crash** on push notifications carrying rich media (`bigPicture`, `largeIcon`, `commonNotificationImage`). Dominated by Samsung devices on Android 16 — One UI's aggressive memory eviction widens the race window dramatically.

## Real-world impact (Sportnieuws.nl Android — Dutch sports news, RN consumer app)

We previously reported this crash to PushEngage support. Since it wasn't fixed upstream, our app's 5.2.1 release shipped a defensive exception-swallow that demoted the throw to a non-fatal Crashlytics log. This was an emergency mitigation — prior to the swallow, the same bug was generating enough fatal crashes to push our app into Google Play Console's "unhealthy release" / bad-behavior thresholds. We didn't have a way to keep shipping otherwise.

Numbers below are the **last 90 days only** (Crashlytics default window), with the swallow active:

| Stack frame variant | Events | Users |
|---|---:|---:|
| `loadImageAsync$2$1.onResourceReady` | 182,000 | 4,200 |
| `loadImageAsync$2$1.onLoadFailed` | 171,000 | 4,200 |
| **Total (90 days, 5.2.1)** | **~353,000** | **4,200** |

<img width="1006" height="271" alt="image" src="https://github.com/user-attachments/assets/95b3ab2b-ce09-40b9-8d34-540f885dfe1e" />


Same 4,200 users appear in both rows — they're hitting the race condition in both possible Glide callback orderings, which confirms the diagnosis. In unmodified consumer code (no swallow), every one of those events is a process crash.

Our 5.3.0 toolchain bump (`compileSdk 36` / JDK 17) defeated the swallow — R8 reprocessing of the bundled AAR moved the throw past our wrapper, returning the crash to **fatal** at ~390 events/month and rising. That's when we forked the SDK.

An additional ~2,300/month Background ANRs appear to be the same slow-load failure mode where no Glide callback fires before the FCM service is killed — out of scope for this PR, but mentioning since it's the same `loadImageAsync` call site.

## Root cause

`suspendCoroutine` is one-shot. Glide will fire `onLoadCleared` during target tear-down *after* `onResourceReady` has already fired — especially when the FCM background service is killed mid-load. Samsung One UI's aggressive memory eviction and Android 16's stricter background-process enforcement widen the race window.

## Fix

Switch to `kotlinx.coroutines.suspendCancellableCoroutine` and guard every resume site with `if (continuation.isActive)`. The second callback is dropped silently — by definition the first callback already drove the bitmap into the notification render path, so dropping the duplicate is a no-op for what the user sees.

## Reproducer

1. Send a push notification with `bigPicture` or `largeIcon` set.
2. Target a Samsung device running Android 16.
3. Trigger conditions where the FCM service is short-lived (low memory or slow network reliably reproduce).
4. Observe `IllegalStateException("Already resumed")` from `PENotificationImageLoader$loadImageAsync$2$1.onResourceReady` (or `.onLoadFailed`, depending on callback order).

## Verification

- +6/-6 in a single file, no public API change.
- Behavior is identical to the current implementation when only one Glide callback fires (the common case).
- We've been running this patch in production via a fork (`com.github.yvocilon:pushengage-android-sdk:0.0.6-appcore.1`) since 2026-05-15 with no regressions.

Happy to follow up with an additional PR for the ANR-window issue (`withTimeoutOrNull` around the same call site) if this one is acceptable — keeping that separate to avoid bundling unrelated changes.
